### PR TITLE
feat: update surplus detail to show each transaction item

### DIFF
--- a/src/routes/EventDetailView/DebtCard.tsx
+++ b/src/routes/EventDetailView/DebtCard.tsx
@@ -15,7 +15,7 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
       <div className="p-4">
         <p className="text-l font-semibold text-slate-500">Bayar ke:</p>
 
-        {debts.map((debt) => {
+        {debts.map((debt, debtIndex) => {
           const hasSurplus = debt.surplus.length > 0;
           const subTotalDebt = debt.transactions.reduce(
             (prev, curr) => prev + curr.debtAfterDiscountAndTax,
@@ -25,10 +25,14 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
             (prev, curr) => prev + curr.debtAfterDiscountAndTax,
             0
           );
+          const lastDebt = debtIndex === debts.length - 1;
 
           return (
             <div
-              className={clsx('mt-2 pb-4', hasMoreThanOneDebt && 'border-b-1')}
+              className={clsx(
+                'mt-2 pb-4',
+                hasMoreThanOneDebt && !lastDebt && 'border-b-1'
+              )}
               key={debt.payer}
             >
               <Collapse

--- a/src/routes/EventDetailView/DebtCard.tsx
+++ b/src/routes/EventDetailView/DebtCard.tsx
@@ -1,9 +1,12 @@
 import { Collapse } from '@/components/Collapse';
 import { formatCurrencyIDR } from '@/utils/currency';
 import { PersonWithDebt } from '@/utils/debts';
+import clsx from 'clsx';
 import { memo } from 'react';
 
 const DebtCard = ({ name, debts }: PersonWithDebt) => {
+  const hasMoreThanOneDebt = debts.length > 1;
+
   return (
     <div className="bg-card rounded-sm shadow-2xs">
       <div className="border-b p-4">
@@ -24,7 +27,10 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
           );
 
           return (
-            <div className="mt-2 pb-4 border-b-1" key={debt.payer}>
+            <div
+              className={clsx('mt-2 pb-4', hasMoreThanOneDebt && 'border-b-1')}
+              key={debt.payer}
+            >
               <Collapse
                 headerContent={
                   <div className="flex items-center justify-between">
@@ -45,7 +51,9 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
                 collapsedContent={
                   <div className="flex flex-col gap-2 ml-8 pl-4 border-l-2 mt-4">
                     <div>
-                      <p className="text-md">🔻 {name} ditraktir {debt.payer}:</p>
+                      <p className="text-md">
+                        🔻 {name} ditraktir {debt.payer}:
+                      </p>
 
                       {debt.transactions.map((transaction) => (
                         <div
@@ -74,13 +82,13 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
                       </div>
                     </div>
 
-                    <div className="mt-8">
-                      <p className="text-md">
-                        🟢 {name} mentraktir {debt.payer}:
-                      </p>
+                    {hasSurplus && (
+                      <div className="mt-8">
+                        <p className="text-md">
+                          🟢 {name} mentraktir {debt.payer}:
+                        </p>
 
-                      {hasSurplus &&
-                        debt.surplus.map((s) => (
+                        {debt.surplus.map((s) => (
                           <div
                             className="flex items-center justify-between"
                             key={s.title}
@@ -95,14 +103,15 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
                           </div>
                         ))}
 
-                      <div className="flex items-center justify-between pt-2 mt-2 border-t">
-                        <p className="text-md text-slate-500">Subtotal</p>
+                        <div className="flex items-center justify-between pt-2 mt-2 border-t">
+                          <p className="text-md text-slate-500">Subtotal</p>
 
-                        <p className="text-md text-slate-500 self-start">
-                          {formatCurrencyIDR(subTotalSurplus)}
-                        </p>
+                          <p className="text-md text-slate-500 self-start">
+                            {formatCurrencyIDR(subTotalSurplus)}
+                          </p>
+                        </div>
                       </div>
-                    </div>
+                    )}
                   </div>
                 }
               />

--- a/src/routes/EventDetailView/DebtCard.tsx
+++ b/src/routes/EventDetailView/DebtCard.tsx
@@ -12,57 +12,103 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
       <div className="p-4">
         <p className="text-l font-semibold text-slate-500">Bayar ke:</p>
 
-        {debts.map((debt) => (
-          <div className="mt-2 pb-4 border-b-1" key={debt.payer}>
-            <Collapse
-              headerContent={
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-l font-semibold text-slate-900">
-                      {debt.payer}
-                    </p>
-                    <p className="text-sm text-slate-400">
-                      Tap untuk lihat detail
+        {debts.map((debt) => {
+          const hasSurplus = debt.surplus.length > 0;
+          const subTotalDebt = debt.transactions.reduce(
+            (prev, curr) => prev + curr.debtAfterDiscountAndTax,
+            0
+          );
+          const subTotalSurplus = debt.surplus.reduce(
+            (prev, curr) => prev + curr.debtAfterDiscountAndTax,
+            0
+          );
+
+          return (
+            <div className="mt-2 pb-4 border-b-1" key={debt.payer}>
+              <Collapse
+                headerContent={
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-l font-semibold text-slate-900">
+                        {debt.payer}
+                      </p>
+                      <p className="text-sm text-slate-400">
+                        Tap untuk lihat detail
+                      </p>
+                    </div>
+
+                    <p className="text-xl font-semibold text-slate-900">
+                      {formatCurrencyIDR(debt.totalDebtAfterDiscountAndTax)}
                     </p>
                   </div>
+                }
+                collapsedContent={
+                  <div className="flex flex-col gap-2 ml-8 pl-4 border-l-2 mt-4">
+                    <div>
+                      <p className="text-md">🔻 {name} ditraktir {debt.payer}:</p>
 
-                  <p className="text-xl font-semibold text-slate-900">
-                    {formatCurrencyIDR(debt.totalDebtAfterDiscountAndTax)}
-                  </p>
-                </div>
-              }
-              collapsedContent={
-                <div className="flex flex-col gap-2 ml-8 pl-4 border-l-2 mt-4">
-                  {debt.transactions.map((transaction) => (
-                    <div
-                      className="flex items-center justify-between gap-2"
-                      key={transaction.title}
-                    >
-                      <p className="text-base text-slate-600">
-                        {transaction.title}
-                      </p>
+                      {debt.transactions.map((transaction) => (
+                        <div
+                          className="flex items-center justify-between"
+                          key={transaction.title}
+                        >
+                          <p className="text-base text-red-600">
+                            {transaction.title}
+                          </p>
 
-                      <p className="text-base font-semibold text-red-500 self-start">
-                        -{' '}
-                        {formatCurrencyIDR(transaction.debtAfterDiscountAndTax)}
-                      </p>
+                          <p className="text-base font-semibold text-red-600 self-start">
+                            -{' '}
+                            {formatCurrencyIDR(
+                              transaction.debtAfterDiscountAndTax
+                            )}
+                          </p>
+                        </div>
+                      ))}
+
+                      <div className="flex items-center justify-between pt-2 mt-2 border-t">
+                        <p className="text-md text-slate-500">Subtotal</p>
+
+                        <p className="text-md text-slate-500 self-start">
+                          {formatCurrencyIDR(subTotalDebt)}
+                        </p>
+                      </div>
                     </div>
-                  ))}
 
-                  {debt.surplus > 0 && (
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="text-base text-slate-600">surplus</p>
-
-                      <p className="text-base font-semibold text-emerald-500 self-start">
-                        {formatCurrencyIDR(debt.surplus)}
+                    <div className="mt-8">
+                      <p className="text-md">
+                        🟢 {name} mentraktir {debt.payer}:
                       </p>
+
+                      {hasSurplus &&
+                        debt.surplus.map((s) => (
+                          <div
+                            className="flex items-center justify-between"
+                            key={s.title}
+                          >
+                            <p className="text-base text-emerald-600">
+                              {s.title}
+                            </p>
+
+                            <p className="text-base font-semibold text-emerald-600 self-start">
+                              + {formatCurrencyIDR(s.debtAfterDiscountAndTax)}
+                            </p>
+                          </div>
+                        ))}
+
+                      <div className="flex items-center justify-between pt-2 mt-2 border-t">
+                        <p className="text-md text-slate-500">Subtotal</p>
+
+                        <p className="text-md text-slate-500 self-start">
+                          {formatCurrencyIDR(subTotalSurplus)}
+                        </p>
+                      </div>
                     </div>
-                  )}
-                </div>
-              }
-            />
-          </div>
-        ))}
+                  </div>
+                }
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/routes/ExpenseListForm/utils.ts
+++ b/src/routes/ExpenseListForm/utils.ts
@@ -1,0 +1,15 @@
+import { personDefaultValues } from '../PersonListForm/defaultValues';
+import { ExpenseType } from './types';
+
+export const resetExpense = (expense: ExpenseType) => {
+  const newExpense = {
+    ...expense,
+    items: expense.items.map((i) => ({
+      ...i,
+      payer: personDefaultValues,
+      receiver: [''],
+    })),
+  };
+
+  return newExpense;
+};

--- a/src/routes/PersonListForm/PersonListForm.tsx
+++ b/src/routes/PersonListForm/PersonListForm.tsx
@@ -12,6 +12,8 @@ import {
   ERROR_MESSAGE_REQUIRED,
 } from '@/constants/forms';
 import NotFoundPage from '../NotFoundPage';
+import { EventType } from '../EventForm/types';
+import { resetExpense } from '../ExpenseListForm/utils';
 
 type PersonListFormValues = {
   personList: PersonType[];
@@ -42,6 +44,8 @@ const PersonListForm = () => {
     name: 'personList',
   });
 
+  const updatedExpenseData = resetExpense(normalizedEventData.expense);
+
   if (!title) return <NotFoundPage />;
 
   return (
@@ -55,8 +59,9 @@ const PersonListForm = () => {
 
       <form
         onSubmit={handleSubmit((data) => {
-          const updatedEvent = {
+          const updatedEvent: EventType = {
             ...normalizedEventData,
+            expense: updatedExpenseData,
             personList: data.personList,
           };
 
@@ -126,7 +131,7 @@ const PersonListForm = () => {
           primaryButtonText="Lanjut tambah pengeluaran"
           secondaryButtonText="Balik edit nama acara"
           onClickSecondaryButton={handleSubmit((data) => {
-            const updatedEvent = {
+            const updatedEvent: EventType = {
               ...normalizedEventData,
               personList: data.personList,
             };

--- a/src/utils/debts.ts
+++ b/src/utils/debts.ts
@@ -1,13 +1,15 @@
 import { ExpenseType } from '../routes/ExpenseListForm/types';
 
+type Transaction = {
+  title: string;
+  debtAfterDiscountAndTax: number;
+};
+
 export type Debt = {
   payer: string;
   totalDebtAfterDiscountAndTax: number;
-  surplus: number;
-  transactions: {
-    title: string;
-    debtAfterDiscountAndTax: number;
-  }[];
+  surplus: Transaction[];
+  transactions: Transaction[];
 };
 
 export type PersonWithDebt = {
@@ -85,7 +87,7 @@ function createArrOfDebts(
           arrDebts.push({
             payer: transaction.payer.name,
             totalDebtAfterDiscountAndTax: debtAfterDiscountAndTax,
-            surplus: 0,
+            surplus: [],
             transactions: [
               {
                 title: transaction.title,
@@ -142,7 +144,7 @@ function normalizeArrOfDebts(
               totalDebtAfterDiscountAndTax:
                 currentPersonDebt.totalDebtAfterDiscountAndTax -
                 currentPayerDebt,
-              surplus: currentPayerDebt,
+              surplus: currentPayerDebtData?.transactions || [],
             };
           }
         }


### PR DESCRIPTION
As per suggestion about ux from chatGPT (lol wkwkwk). To promote transparency as money app, it seems better if the app can show each of the transaction that makes the surplus

I thought it would be a hard and tedious changes, but Thanks God the changes is much simpler as the transaction object is already there