### PR TITLE
feat: add thousand separator

### DIFF
--- a/src/constants/forms.ts
+++ b/src/constants/forms.ts
@@ -2,5 +2,4 @@ export const ERROR_MESSAGE_REQUIRED = 'wajib diisi ya';
 export const ERROR_MESSAGE_NAME_DUPLICATE = 'namanya jangan sama ya';
 export const ERROR_MESSAGE_MIN_RP_0 = 'minimal Rp0';
 export const ERROR_MESSAGE_MIN_RP_1 = 'minimal Rp1';
-export const ERROR_MESSAGE_MIN_TAX = 'minimal 0';
 export const ERROR_MESSAGE_MAX_PERCENTAGE_TAX = 'Maksimal 100%';

--- a/src/routes/ExpenseListForm/defaultValues.ts
+++ b/src/routes/ExpenseListForm/defaultValues.ts
@@ -3,8 +3,7 @@ import { ExpenseType, ItemType } from './types';
 
 export const itemDefaultValues: ItemType = {
   title: '',
-  price: 0,
-  formattedStringPrice: '',
+  price: '0',
   payer: personDefaultValues,
   receiver: [''],
 };
@@ -12,15 +11,15 @@ export const itemDefaultValues: ItemType = {
 export const expenseDefaultValues: ExpenseType = {
   items: [itemDefaultValues],
   tax: {
-    value: 0,
+    value: '0',
     type: 'PERCENTAGE',
   },
   discount: {
-    value: 0,
+    value: '0',
     type: 'AMOUNT',
   },
   serviceCharge: {
-    value: 0,
+    value: '0',
     type: 'AMOUNT',
   },
 };

--- a/src/routes/ExpenseListForm/types.ts
+++ b/src/routes/ExpenseListForm/types.ts
@@ -2,8 +2,7 @@ import { PersonType } from '../PersonListForm/types';
 
 export type ItemType = {
   title: string;
-  price: number;
-  formattedStringPrice: string;
+  price: string;
   payer: PersonType;
   receiver: string[];
 };
@@ -13,15 +12,15 @@ export type DynacicPercentageValue = 'PERCENTAGE' | 'AMOUNT';
 export type ExpenseType = {
   items: ItemType[];
   tax: {
-    value: number;
+    value: string;
     type: DynacicPercentageValue;
   };
   discount: {
-    value: number;
+    value: string;
     type: DynacicPercentageValue;
   };
   serviceCharge: {
-    value: number;
+    value: string;
     type: DynacicPercentageValue;
   };
 };

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -59,9 +59,11 @@ const Home = ({
 
       <div className="grid gap-4 md:grid-cols-2">
         {eventList.map((event) => {
-          const expensesPrice = event.expense.items.map((item) => item.price);
+          const expensesPrice = event.expense.items.map((item) =>
+            Number(item.price)
+          );
           const totalExpense = expensesPrice.reduce(
-            (prev, curr) => Number(prev) + Number(curr)
+            (prev, curr) => prev + curr
           );
 
           return (

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -6,7 +6,12 @@ export const formatCurrencyIDR = (price: number) => {
   }).format(price);
 };
 
-export const formatNumberWithThousandSeparator = (value: number): string => {
-  const formatter = new Intl.NumberFormat('id-ID');
-  return formatter.format(value);
+export const formatThousandSeparator = (value: string): string => {
+  const parsedToStringValue = String(value);
+  
+  const num = Number(parsedToStringValue.replace(/\D/g, ''));
+  return isNaN(num) ? '' : new Intl.NumberFormat('id-ID').format(num);
 };
+
+export const unformatThousandSeparator = (formatted: string): string =>
+  formatted.replace(/\D/g, '');

--- a/src/utils/debts.ts
+++ b/src/utils/debts.ts
@@ -26,14 +26,16 @@ export type PersonWithDebt = {
 
 function getAmount(
   type: DynacicPercentageValue,
-  percentageValue: number,
+  percentageValue: string | number,
   total: number,
   pricePerPerson: number
 ): number {
-  if (type === 'AMOUNT') return Number(percentageValue * total);
-  if (!percentageValue) return 0;
+  const formattedPercentageValue = Number(percentageValue);
 
-  return (percentageValue / 100) * pricePerPerson;
+  if (type === 'AMOUNT') return Number(formattedPercentageValue * total);
+  if (!formattedPercentageValue) return 0;
+
+  return (formattedPercentageValue / 100) * pricePerPerson;
 }
 
 function createArrOfDebts(
@@ -45,10 +47,8 @@ function createArrOfDebts(
   return arrPerson.map((person) => {
     let arrDebts: Debt[] = [];
 
-    const expensesPrice = items.map((item) => item.price);
-    const totalExpense = expensesPrice.reduce(
-      (prev, curr) => Number(prev) + Number(curr)
-    );
+    const expensesPrice = items.map((item) => Number(item.price));
+    const totalExpense = expensesPrice.reduce((prev, curr) => prev + curr);
 
     items.forEach((transaction) => {
       // check if person is not payer but includes as receiver
@@ -66,9 +66,9 @@ function createArrOfDebts(
 
         // count the ratio of current transaction price to total expense (before discount & tax)
         const ratioTransactionPriceToTotalExpense =
-          transaction.price / totalReceivers / totalExpense;
+          Number(transaction.price) / totalReceivers / totalExpense;
 
-        const pricePerPerson = transaction.price / totalReceivers;
+        const pricePerPerson = Number(transaction.price) / totalReceivers;
 
         // normalize discount
         const discountAmount = getAmount(

--- a/src/utils/normalizer.ts
+++ b/src/utils/normalizer.ts
@@ -18,15 +18,15 @@ export const normalizeEventData = (event: EventType | undefined): EventType => {
           : event?.expense?.items,
       tax: {
         type: event?.expense?.tax?.type || 'PERCENTAGE',
-        value: event?.expense?.tax?.value || 0,
+        value: event?.expense?.tax?.value || '0',
       },
       discount: {
         type: event?.expense?.discount?.type || 'PERCENTAGE',
-        value: event?.expense?.discount?.value || 0,
+        value: event?.expense?.discount?.value || '0',
       },
       serviceCharge: {
         type: event?.expense?.serviceCharge?.type || 'PERCENTAGE',
-        value: event?.expense?.serviceCharge?.value || 0,
+        value: event?.expense?.serviceCharge?.value || '0',
       },
     },
   };


### PR DESCRIPTION
With the help from AI, I tried other alternatives for adding thousand separator

previous implementation was using double form values and I need to manually switch back and forth everytime editing and viewing the values XD

my concern was I current implementation is using number as a type, it will be a lot easier it was string type for adding thousand separator, but I insist to using number for backward compatibility

after trying some alternatives (one of them was using [react-number-format](https://s-yadav.github.io/react-number-format/) -- but turns out it has it own issue if I want to use dots (.) as thousand separator (https://github.com/s-yadav/react-number-format/issues/191, https://github.com/s-yadav/react-number-format/issues/34)). I decided to change the pricing, tax, discount and serviceCharge value to string -- with parsing every number value to string to support backward compatibility

the results was expected: the old data in user local storage was overwritten using string instead if the usser try to edit them
<img width="1131" alt="Screenshot 2025-06-29 at 12 38 30" src="https://github.com/user-attachments/assets/193452f1-7eae-47de-bd74-35a54d4010dc" />

