### PR TITLE
feat: add detail transaction for each person tab on the result page

### DIFF
--- a/src/routes/EventDetailView/DebtCard.tsx
+++ b/src/routes/EventDetailView/DebtCard.tsx
@@ -4,8 +4,151 @@ import { PersonWithDebt } from '@/utils/debts';
 import clsx from 'clsx';
 import { memo } from 'react';
 
+const AdjustmentRow = ({
+  label,
+  value,
+  color = 'text-slate-500',
+  prefix = '',
+}: {
+  label: string;
+  value: number;
+  color?: string;
+  prefix?: string;
+}) => (
+  <div className="flex items-center justify-between">
+    <p className={`text-base ${color}`}>{label}</p>
+    <p className={`text-base ${color} self-start`}>
+      {prefix}
+      {formatCurrencyIDR(value)}
+    </p>
+  </div>
+);
+
+const SubtotalRow = ({
+  label,
+  value,
+  color = 'text-slate-700',
+}: {
+  label: string;
+  value: number;
+  color?: string;
+}) => (
+  <div className="flex items-center justify-between pt-2 mt-2 border-t">
+    <p className={`text-md font-semibold ${color}`}>{label}</p>
+    <p className={`text-md self-start font-semibold ${color}`}>
+      {formatCurrencyIDR(value)}
+    </p>
+  </div>
+);
+
+const TransactionSection = ({
+  name,
+  payer,
+  items,
+  adjustments,
+  subtotal,
+  icon,
+  color,
+  sign,
+  label,
+}: {
+  name: string;
+  payer: string;
+  items: { title: string; basePrice: number }[];
+  adjustments: { tax: number; service: number; discount: number };
+  subtotal: number;
+  icon: string;
+  color: string;
+  sign: string;
+  label: string;
+}) => (
+  <div className={color === 'emerald' ? 'mt-8' : ''}>
+    <p className="text-md mb-2">
+      {icon} {name} {label} {payer}:
+    </p>
+    {items.map((item) => (
+      <div className="flex items-center justify-between" key={item.title}>
+        <p className={`text-base text-${color}-600`}>{item.title}</p>
+        <p className={`text-base font-semibold text-${color}-600 self-start`}>
+          {sign} {formatCurrencyIDR(item.basePrice)}
+        </p>
+      </div>
+    ))}
+    {(adjustments.tax > 0 ||
+      adjustments.service > 0 ||
+      adjustments.discount > 0) && (
+      <div className="mt-2 pt-2 border-t">
+        {adjustments.tax > 0 && (
+          <AdjustmentRow label="Pajak" value={adjustments.tax} />
+        )}
+        {adjustments.service > 0 && (
+          <AdjustmentRow label="Biaya Layanan" value={adjustments.service} />
+        )}
+        {adjustments.discount > 0 && (
+          <AdjustmentRow
+            label="Diskon"
+            value={adjustments.discount}
+            color="text-emerald-600"
+            prefix="+ "
+          />
+        )}
+      </div>
+    )}
+    <SubtotalRow label="Subtotal" value={subtotal} />
+  </div>
+);
+
+// --- Main DebtCard ---
 const DebtCard = ({ name, debts }: PersonWithDebt) => {
   const hasMoreThanOneDebt = debts.length > 1;
+
+  // Preprocess all data for subcomponents
+  const processedDebts = debts.map((debt, debtIndex) => {
+    const debtAdjustments = {
+      tax: debt.transactions.reduce((prev, curr) => prev + curr.tax, 0),
+      service: debt.transactions.reduce(
+        (prev, curr) => prev + curr.serviceCharge,
+        0
+      ),
+      discount: debt.transactions.reduce(
+        (prev, curr) => prev + curr.discount,
+        0
+      ),
+    };
+    const surplusAdjustments = {
+      tax: debt.surplus.reduce((prev, curr) => prev + curr.tax, 0),
+      service: debt.surplus.reduce(
+        (prev, curr) => prev + curr.serviceCharge,
+        0
+      ),
+      discount: debt.surplus.reduce((prev, curr) => prev + curr.discount, 0),
+    };
+    return {
+      key: debt.payer,
+      payer: debt.payer,
+      transactions: debt.transactions.map((t) => ({
+        title: t.title,
+        basePrice: t.basePrice,
+      })),
+      debtAdjustments,
+      debtSubtotal: debt.transactions.reduce(
+        (prev, curr) => prev + curr.debtAfterDiscountAndTax,
+        0
+      ),
+      surplus: debt.surplus.map((s) => ({
+        title: s.title,
+        basePrice: s.basePrice,
+      })),
+      surplusAdjustments,
+      surplusSubtotal: debt.surplus.reduce(
+        (prev, curr) => prev + curr.debtAfterDiscountAndTax,
+        0
+      ),
+      total: debt.totalDebtAfterDiscountAndTax,
+      hasSurplus: debt.surplus.length > 0,
+      lastDebt: debtIndex === debts.length - 1,
+    };
+  });
 
   return (
     <div className="bg-card rounded-sm shadow-2xs">
@@ -14,237 +157,61 @@ const DebtCard = ({ name, debts }: PersonWithDebt) => {
       </div>
       <div className="p-4">
         <p className="text-l font-semibold text-slate-500">Bayar ke:</p>
-
-        {debts.map((debt, debtIndex) => {
-          const hasSurplus = debt.surplus.length > 0;
-          const subTotalDebt = debt.transactions.reduce(
-            (prev, curr) => prev + curr.debtAfterDiscountAndTax,
-            0
-          );
-          const subTotalSurplus = debt.surplus.reduce(
-            (prev, curr) => prev + curr.debtAfterDiscountAndTax,
-            0
-          );
-
-          const lastDebt = debtIndex === debts.length - 1;
-
-          const totalDebtDiscountAmount = debt.transactions.reduce(
-            (prev, curr) => prev + curr.discount,
-            0
-          );
-
-          const totalDebtTaxAmount = debt.transactions.reduce(
-            (prev, curr) => prev + curr.tax,
-            0
-          );
-
-          const totalDebtServiceChargeAmount = debt.transactions.reduce(
-            (prev, curr) => prev + curr.serviceCharge,
-            0
-          );
-
-          const hasDebtDiscountOrAdditionalCharge =
-            totalDebtDiscountAmount > 0 ||
-            totalDebtTaxAmount > 0 ||
-            totalDebtServiceChargeAmount > 0;
-
-          const totalSurplusDiscountAmount = debt.surplus.reduce(
-            (prev, curr) => prev + curr.discount,
-            0
-          );
-
-          const totalSurplusTaxAmount = debt.surplus.reduce(
-            (prev, curr) => prev + curr.tax,
-            0
-          );
-
-          const totalSurplusServiceChargeAmount = debt.surplus.reduce(
-            (prev, curr) => prev + curr.serviceCharge,
-            0
-          );
-
-          const hasSurplusDiscountOrAdditionalCharge =
-            totalSurplusDiscountAmount > 0 ||
-            totalSurplusTaxAmount > 0 ||
-            totalSurplusServiceChargeAmount > 0;
-
-          return (
-            <div
-              className={clsx(
-                'mt-2 pb-4',
-                hasMoreThanOneDebt && !lastDebt && 'border-b-1'
-              )}
-              key={debt.payer}
-            >
-              <Collapse
-                headerContent={
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-l font-semibold text-slate-900">
-                        {debt.payer}
-                      </p>
-                      <p className="text-sm text-slate-400">
-                        Tap untuk lihat detail
-                      </p>
-                    </div>
-
-                    <p className="text-xl font-semibold text-slate-900">
-                      {formatCurrencyIDR(debt.totalDebtAfterDiscountAndTax)}
+        {processedDebts.map((d) => (
+          <div
+            className={clsx(
+              'mt-2 pb-4',
+              hasMoreThanOneDebt && !d.lastDebt && 'border-b-1'
+            )}
+            key={d.key}
+          >
+            <Collapse
+              headerContent={
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-l font-semibold text-slate-900">
+                      {d.payer}
+                    </p>
+                    <p className="text-sm text-slate-400">
+                      Tap untuk lihat detail
                     </p>
                   </div>
-                }
-                collapsedContent={
-                  <div className="flex flex-col gap-2 ml-8 pl-4 border-l-2 mt-4">
-                    <div>
-                      <p className="text-md mb-2">
-                        🔻 {name} ditraktir {debt.payer}:
-                      </p>
-
-                      {debt.transactions.map((transaction) => (
-                        <div
-                          className="flex items-center justify-between"
-                          key={transaction.title}
-                        >
-                          <p className="text-base text-red-600">
-                            {transaction.title}
-                          </p>
-
-                          <p className="text-base font-semibold text-red-600 self-start">
-                            - {formatCurrencyIDR(transaction.basePrice)}
-                          </p>
-                        </div>
-                      ))}
-
-                      <div
-                        className={clsx(
-                          hasDebtDiscountOrAdditionalCharge &&
-                            'mt-2 pt-2 border-t'
-                        )}
-                      >
-                        {totalDebtTaxAmount > 0 && (
-                          <div className="flex items-center justify-between">
-                            <p className="text-base text-slate-500">Pajak</p>
-
-                            <p className="text-base text-slate-500 self-start">
-                              {formatCurrencyIDR(totalDebtTaxAmount)}
-                            </p>
-                          </div>
-                        )}
-
-                        {totalDebtServiceChargeAmount > 0 && (
-                          <div className="flex items-center justify-between">
-                            <p className="text-base text-slate-500">
-                              Biaya Layanan
-                            </p>
-
-                            <p className="text-base text-slate-500 self-start">
-                              {formatCurrencyIDR(totalDebtServiceChargeAmount)}
-                            </p>
-                          </div>
-                        )}
-
-                        {totalDebtDiscountAmount > 0 && (
-                          <div className="flex items-center justify-between">
-                            <p className="text-base text-emerald-600">Diskon</p>
-
-                            <p className="text-base text-emerald-600 self-start">
-                              + {formatCurrencyIDR(totalDebtDiscountAmount)}
-                            </p>
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="flex items-center justify-between pt-2 mt-2 border-t">
-                        <p className="text-md text-slate-700 font-semibold">
-                          Subtotal
-                        </p>
-
-                        <p className="text-md text-slate-700 self-start font-semibold">
-                          {formatCurrencyIDR(subTotalDebt)}
-                        </p>
-                      </div>
-                    </div>
-
-                    {hasSurplus && (
-                      <div className="mt-8">
-                        <p className="text-md mb-2">
-                          🟢 {name} mentraktir {debt.payer}:
-                        </p>
-
-                        {debt.surplus.map((s) => (
-                          <div
-                            className="flex items-center justify-between"
-                            key={s.title}
-                          >
-                            <p className="text-base text-emerald-600">
-                              {s.title}
-                            </p>
-
-                            <p className="text-base font-semibold text-emerald-600 self-start">
-                              + {formatCurrencyIDR(s.basePrice)}
-                            </p>
-                          </div>
-                        ))}
-
-                        <div
-                          className={clsx(
-                            hasSurplusDiscountOrAdditionalCharge &&
-                              'mt-2 pt-2 border-t'
-                          )}
-                        >
-                          {totalSurplusTaxAmount > 0 && (
-                            <div className="flex items-center justify-between">
-                              <p className="text-base text-slate-500">Pajak</p>
-
-                              <p className="text-base text-slate-500 self-start">
-                                {formatCurrencyIDR(totalSurplusTaxAmount)}
-                              </p>
-                            </div>
-                          )}
-
-                          {totalSurplusServiceChargeAmount > 0 && (
-                            <div className="flex items-center justify-between">
-                              <p className="text-base text-slate-500">
-                                Biaya Layanan
-                              </p>
-
-                              <p className="text-base text-slate-500 self-start">
-                                {formatCurrencyIDR(
-                                  totalSurplusServiceChargeAmount
-                                )}
-                              </p>
-                            </div>
-                          )}
-
-                          {totalSurplusDiscountAmount > 0 && (
-                            <div className="flex items-center justify-between">
-                              <p className="text-base text-emerald-600">
-                                Diskon
-                              </p>
-
-                              <p className="text-base text-emerald-600 self-start">
-                                +{' '}
-                                {formatCurrencyIDR(totalSurplusDiscountAmount)}
-                              </p>
-                            </div>
-                          )}
-                        </div>
-
-                        <div className="flex items-center justify-between pt-2 mt-2 border-t">
-                          <p className="text-md text-slate-500">Subtotal</p>
-
-                          <p className="text-md text-slate-500 self-start">
-                            {formatCurrencyIDR(subTotalSurplus)}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                }
-              />
-            </div>
-          );
-        })}
+                  <p className="text-xl font-semibold text-slate-900">
+                    {formatCurrencyIDR(d.total)}
+                  </p>
+                </div>
+              }
+              collapsedContent={
+                <div className="flex flex-col gap-2 ml-8 pl-4 border-l-2 mt-4">
+                  <TransactionSection
+                    name={name}
+                    payer={d.payer}
+                    items={d.transactions}
+                    adjustments={d.debtAdjustments}
+                    subtotal={d.debtSubtotal}
+                    icon="🔻"
+                    color="red"
+                    sign="-"
+                    label="ditraktir"
+                  />
+                  {d.hasSurplus && (
+                    <TransactionSection
+                      name={name}
+                      payer={d.payer}
+                      items={d.surplus}
+                      adjustments={d.surplusAdjustments}
+                      subtotal={d.surplusSubtotal}
+                      icon="🟢"
+                      color="emerald"
+                      sign="+"
+                      label="mentraktir"
+                    />
+                  )}
+                </div>
+              }
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/routes/EventDetailView/EventDetailView.tsx
+++ b/src/routes/EventDetailView/EventDetailView.tsx
@@ -1,4 +1,4 @@
-import { createArrOfDebts, normalizeArrOfDebts } from '../../utils/debts';
+import { creatDetailedTransactionsForEachPerson, createArrOfDebts, normalizeArrOfDebts, normalizeArrTransactionsForEachPerson } from '../../utils/debts';
 import { useNavigate, useParams } from 'react-router';
 import { EventType } from '../EventForm/types';
 import { eventDefaultValues } from '../EventForm/defaultValues';
@@ -16,12 +16,15 @@ import {
   DrawerTrigger,
 } from '@/components/ui/drawer';
 import NotFoundPage from '../NotFoundPage';
+import { useState } from 'react';
 
 const EventDetailView = ({ eventList }: { eventList: EventType[] }) => {
   const { eventId } = useParams();
   const navigate = useNavigate();
 
   const currentEvent = eventList?.find((event) => event.id === eventId);
+
+  const [activeTab, setActiveTab] = useState(0);
 
   const { title, personList, expense } = currentEvent || eventDefaultValues;
 
@@ -33,9 +36,14 @@ const EventDetailView = ({ eventList }: { eventList: EventType[] }) => {
 
   const finalResults = normalizeArrOfDebts(arrOfDebts);
 
+  const detailedTransactionsForEachPerson = creatDetailedTransactionsForEachPerson(expense, personListSToString);
+  const normalizedArrTransactionsForEachPerson = normalizeArrTransactionsForEachPerson(detailedTransactionsForEachPerson);
+  
+  console.log("AAA normalizedArrTransactionsForEachPerson", normalizedArrTransactionsForEachPerson);
+  
   return (
-    <main className="p-8 max-w-lg mx-auto">
-      <div className="text-left mb-8 flex gap-2 items-start justify-between">
+    <main className="max-w-lg mx-auto py-8">
+      <div className="text-left mb-4 flex gap-2 items-start justify-between mx-8">
         <h1 className="text-4xl font-bold tracking-tight text-slate-900">
           {title}
         </h1>
@@ -49,7 +57,7 @@ const EventDetailView = ({ eventList }: { eventList: EventType[] }) => {
         </Button>
       </div>
 
-      <div className="p-2 rounded-lg flex gap-2 text-slate-800 text-sm items-center">
+      <div className="p-2 rounded-lg flex gap-2 text-slate-800 text-sm items-center mx-8">
         <p>Datanya disimpan lokal di perangkat kamu</p>
 
         <Drawer>
@@ -90,7 +98,30 @@ const EventDetailView = ({ eventList }: { eventList: EventType[] }) => {
         </Drawer>
       </div>
 
-      <div className="flex flex-col gap-4 mt-4">
+      <div className="flex border-b border-gray-200 px-6 justify-around">
+        <button
+          className={`py-3 px-4 font-medium text-sm ${
+            activeTab === 0
+              ? 'text-slate-900 border-b-2 border-slate-900'
+              : 'text-slate-500'
+          }`}
+          onClick={() => setActiveTab(0)}
+        >
+          Normalized Result
+        </button>
+        <button
+          className={`py-3 px-4 font-medium text-sm ${
+            activeTab === 1
+              ? 'text-slate-900 border-b-2 border-slate-900'
+              : 'text-slate-500'
+          }`}
+          onClick={() => setActiveTab(1)}
+        >
+          Transaction Details
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-4 mt-4 mx-8">
         {finalResults.map((person) => {
           const filteredDebt = person.debts.filter(
             (d) => d?.totalDebtAfterDiscountAndTax
@@ -108,13 +139,15 @@ const EventDetailView = ({ eventList }: { eventList: EventType[] }) => {
         })}
       </div>
 
-      <Button
-        onClick={() => navigate('/')}
-        type="button"
-        className="w-full bg-primary hover:bg-primary-variant hover:bg-slate-800 text-white h-12 whitespace-normal mt-4"
-      >
-        Balik ke Home
-      </Button>
+      <div className="mx-8">
+        <Button
+          onClick={() => navigate('/')}
+          type="button"
+          className="w-full bg-primary hover:bg-primary-variant hover:bg-slate-800 text-white h-12 whitespace-normal mt-4"
+        >
+          Balik ke Home
+        </Button>
+      </div>
     </main>
   );
 };

--- a/src/routes/EventDetailView/TransactionCard.tsx
+++ b/src/routes/EventDetailView/TransactionCard.tsx
@@ -1,0 +1,158 @@
+import { Collapse } from '@/components/Collapse';
+import { formatCurrencyIDR } from '@/utils/currency';
+
+// --- Transaction Components ---
+const AdjustmentRow = ({
+  label,
+  value,
+  color = 'text-slate-500',
+  prefix = '',
+}: {
+  label: string;
+  value: number;
+  color?: string;
+  prefix?: string;
+}) => (
+  <div className="flex items-center justify-between">
+    <p className={`text-base ${color}`}>{label}</p>
+    <p className={`text-base ${color} self-start`}>
+      {prefix}
+      {formatCurrencyIDR(value)}
+    </p>
+  </div>
+);
+
+const SubtotalRow = ({
+  label,
+  value,
+  color = 'text-slate-700',
+}: {
+  label: string;
+  value: number;
+  color?: string;
+}) => (
+  <div className="flex items-center justify-between pt-2 mt-2 border-t">
+    <p className={`text-md font-semibold ${color}`}>{label}</p>
+    <p className={`text-md self-start font-semibold ${color}`}>
+      {formatCurrencyIDR(value)}
+    </p>
+  </div>
+);
+
+const TransactionSection = ({
+  name,
+  payer,
+  items,
+  adjustments,
+  subtotal,
+  icon,
+  color,
+  sign,
+  label,
+  variant = 'debt',
+}: {
+  items: { title: string; basePrice: number }[];
+  adjustments: { tax: number; service: number; discount: number };
+  subtotal: number;
+  color: string;
+  sign: string;
+  icon?: string;
+  label?: string;
+  payer?: string;
+  name?: string;
+  variant?: 'debt' | 'transaction';
+}) => (
+  <div className={color === 'emerald' ? 'mt-8' : ''}>
+    {variant === 'debt' && (
+      <p className="text-md mb-2">
+        {icon} {name} {label} {payer}:
+      </p>
+    )}
+    {items.map((item) => (
+      <div className="flex items-center justify-between" key={item.title}>
+        <p className={`text-base text-${color}-500`}>{item.title}</p>
+        <p className={`text-base font-semibold text-${color}-500 self-start`}>
+          {sign} {formatCurrencyIDR(item.basePrice)}
+        </p>
+      </div>
+    ))}
+    {(adjustments.tax > 0 ||
+      adjustments.service > 0 ||
+      adjustments.discount > 0) && (
+      <div className="mt-2 pt-2 border-t">
+        {adjustments.tax > 0 && (
+          <AdjustmentRow label="Pajak" value={adjustments.tax} />
+        )}
+        {adjustments.service > 0 && (
+          <AdjustmentRow label="Biaya Layanan" value={adjustments.service} />
+        )}
+        {adjustments.discount > 0 && (
+          <AdjustmentRow
+            label="Diskon"
+            value={adjustments.discount}
+            color="text-emerald-500"
+            prefix="+ "
+          />
+        )}
+      </div>
+    )}
+    <SubtotalRow label="Subtotal" value={subtotal} />
+  </div>
+);
+
+// --- Composable Components ---
+const TransactionCard = ({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <div className={`bg-card rounded-sm shadow-2xs ${className}`}>{children}</div>
+);
+
+const TransactionTitle = ({ children }: { children: React.ReactNode }) => (
+  <div className="border-b p-4">
+    <h2 className="text-xl font-bold text-slate-800">{children}</h2>
+  </div>
+);
+
+const TransactionPayTo = ({
+  prefix,
+  children,
+}: {
+  prefix?: string;
+  children: React.ReactNode;
+}) => (
+  <div className="p-4">
+    {prefix && <p className="text-l font-semibold text-slate-500">{prefix}</p>}
+    {children}
+  </div>
+);
+
+const TransactionDebtCollapse = ({
+  headerContent,
+  children,
+  className = '',
+  keyProp,
+}: {
+  headerContent: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  keyProp: string;
+}) => (
+  <div className={className} key={keyProp}>
+    <Collapse headerContent={headerContent} collapsedContent={children} />
+  </div>
+);
+
+// --- Export all as named exports for composability ---
+export {
+  TransactionCard,
+  TransactionTitle,
+  TransactionPayTo,
+  TransactionDebtCollapse,
+  TransactionSection,
+  AdjustmentRow,
+  SubtotalRow,
+};

--- a/src/utils/debts.ts
+++ b/src/utils/debts.ts
@@ -3,7 +3,7 @@ import {
   ExpenseType,
 } from '../routes/ExpenseListForm/types';
 
-type Transaction = {
+export type Transaction = {
   title: string;
   debtAfterDiscountAndTax: number;
   basePrice: number;

--- a/src/utils/debts.ts
+++ b/src/utils/debts.ts
@@ -32,7 +32,7 @@ function getAmount(
 ): number {
   const formattedPercentageValue = Number(percentageValue);
 
-  if (type === 'AMOUNT') return Number(formattedPercentageValue * total);
+  if (type === 'AMOUNT') return formattedPercentageValue * Number(total);
   if (!formattedPercentageValue) return 0;
 
   return (formattedPercentageValue / 100) * pricePerPerson;
@@ -198,4 +198,106 @@ function normalizeArrOfDebts(
   }));
 }
 
-export { createArrOfDebts, normalizeArrOfDebts };
+type ArrTransaction = {
+  name: string;
+  transactions: Transaction[];
+};
+
+function creatDetailedTransactionsForEachPerson(
+  expense: ExpenseType,
+  personListSToString: string[]
+): ArrTransaction[] {
+  const { items, discount, tax, serviceCharge } = expense;
+
+  return personListSToString.map((person) => {
+    const arrTransactions: Transaction[] = [];
+
+    items.forEach((transaction) => {
+      if (transaction.receiver.includes(person)) {
+        const totalReceivers = transaction.receiver?.filter((r) =>
+          Boolean(r)
+        )?.length;
+
+        const expensesPrice = items.map((item) => Number(item.price));
+        const totalExpense = expensesPrice.reduce((prev, curr) => prev + curr);
+
+        // count the ratio of current transaction price to total expense (before discount & tax)
+        const ratioTransactionPriceToTotalExpense =
+          Number(transaction.price) / totalReceivers / totalExpense;
+
+        const pricePerPerson = Number(transaction.price) / totalReceivers;
+
+        // normalize discount
+        const discountAmount = getAmount(
+          discount.type,
+          discount.value,
+          ratioTransactionPriceToTotalExpense,
+          pricePerPerson
+        );
+
+        // normalize tax
+        const taxAmount = getAmount(
+          tax.type,
+          tax.value,
+          ratioTransactionPriceToTotalExpense,
+          pricePerPerson
+        );
+
+        // normalize service charge
+        const serviceChargeAmount = getAmount(
+          serviceCharge.type,
+          serviceCharge.value,
+          ratioTransactionPriceToTotalExpense,
+          pricePerPerson
+        );
+
+        // count the total price after discount, tax, and service charge
+        const debtAfterDiscountTaxServiceCharge =
+          pricePerPerson - discountAmount + taxAmount + serviceChargeAmount;
+
+        arrTransactions.push({
+          title: transaction.title,
+          debtAfterDiscountAndTax: debtAfterDiscountTaxServiceCharge,
+          basePrice: pricePerPerson,
+          discount: discountAmount,
+          tax: taxAmount,
+          serviceCharge: serviceChargeAmount,
+        });
+      }
+    });
+
+    return {
+      name: person,
+      transactions: arrTransactions,
+    };
+  });
+}
+
+function normalizeArrTransactionsForEachPerson(
+  arrTransaction: ArrTransaction[]
+) {
+  return arrTransaction.map((transaction) => {
+    return {
+      ...transaction,
+      totalDiscount: transaction.transactions.reduce(
+        (prev, curr) => prev + curr.discount,
+        0
+      ),
+      totalTax: transaction.transactions.reduce(
+        (prev, curr) => prev + curr.tax,
+        0
+      ),
+      totalServiceCharge: transaction.transactions.reduce(
+        (prev, curr) => prev + curr.serviceCharge,
+        0
+      ),
+    };
+  });
+}
+
+export {
+  createArrOfDebts,
+  normalizeArrOfDebts,
+  creatDetailedTransactionsForEachPerson,
+  normalizeArrTransactionsForEachPerson,
+};


### PR DESCRIPTION
Finally. Have been wondering about the problems my partner's friend talked about how they can track the details of all transactions each person has so they can make balancing with the total on showing the receipt

The first idea creating this app was to just give the final result where each payer debt has reduced by some amount of transactions they already paid, but it seems giving users ability to switch between the "final results" and "detailed transaction for each person" is more versatile. I was never tought if this until someone reminding that they are need this kind of feature.